### PR TITLE
fix(ci): repair CI and scheduled-test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-        pip install safety bandit
-    
-    - name: Run safety check
+
+    - name: Run dependency vulnerability audit (pip-audit)
       run: |
-        safety check
-    
+        pip-audit
+
     - name: Run bandit security check
       run: |
         bandit -r itglue -f json -o bandit-report.json || true

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -135,13 +135,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-        pip install safety bandit semgrep
-    
-    - name: Run safety check
+        pip install semgrep
+
+    - name: Run dependency vulnerability audit (pip-audit)
       run: |
-        safety check --json --output safety-report.json || true
-        safety check
-    
+        pip-audit --format=json --output=pip-audit-report.json || true
+        pip-audit
+
     - name: Run bandit security scan
       run: |
         bandit -r itglue -f json -o bandit-report.json || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **CI**: Reformatted the codebase with Black's current (26.x) stable style and pinned
+  `black>=26.0,<27.0` so the `black --check` gate can no longer drift on a new release.
+- **CI**: Resolved Bandit findings so the security scans pass — set `usedforsecurity=False`
+  on the MD5 cache-key hash (`itglue/cache.py`) and annotated reviewed false positives
+  (B105 field-name mappings, B608 error-message f-string) with `# nosec`.
+- **Scheduled Tests**: Added the missing `performance` optional-dependency group
+  (`psutil`) that the comprehensive-test job installs, fixing the
+  `ModuleNotFoundError: No module named 'psutil'` in the memory-usage check.
+
+### Changed
+- **CI/Security**: Replaced the deprecated, auth-gated `safety check` with PyPA's
+  `pip-audit` for dependency vulnerability scanning in both the CI and Scheduled Tests
+  workflows. `pip-audit` is in the `dev` extra and needs no account to run in CI.
+
 ## [0.2.6] - 2026-05-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scheduled Tests**: Added the missing `performance` optional-dependency group
   (`psutil`) that the comprehensive-test job installs, fixing the
   `ModuleNotFoundError: No module named 'psutil'` in the memory-usage check.
+- **CI (Windows)**: Gated `uvloop` on `sys_platform != 'win32'` in `requirements.txt`;
+  uvloop has no Windows support and was failing the Windows test matrix with
+  `RuntimeError: uvloop does not support Windows`.
 
 ### Changed
 - **CI/Security**: Replaced the deprecated, auth-gated `safety check` with PyPA's

--- a/itglue/api/base.py
+++ b/itglue/api/base.py
@@ -159,9 +159,7 @@ class BaseAPI(Generic[T]):
             logger.error(f"Failed to process {self.resource_type.value} response: {e}")
             raise ITGlueValidationError(f"Invalid response format: {e}")
 
-    def get(
-        self, resource_id: str, include: Optional[List[str]] = None, **kwargs
-    ) -> T:
+    def get(self, resource_id: str, include: Optional[List[str]] = None, **kwargs) -> T:
         """Get a single resource by ID.
 
         Args:
@@ -265,27 +263,27 @@ class BaseAPI(Generic[T]):
         while True:
             page_params = params.copy()
             page_params["page[number]"] = str(page)
-            
+
             response = self.client.get(url, params=page_params)
             if not response or "data" not in response:
                 break
-                
+
             all_data.extend(response["data"])
-            
+
             # Check if there are more pages
             meta = response.get("meta", {})
             if not meta.get("has-next-page", False):
                 break
-                
+
             page += 1
 
         # Create a combined response
         combined_response = {
             "data": all_data,
             "meta": {"total-count": len(all_data)},
-            "links": {}
+            "links": {},
         }
-        
+
         return self._process_response(combined_response, is_collection=True)
 
     def create(self, data: Union[T, Dict[str, Any]], **kwargs) -> T:
@@ -323,9 +321,7 @@ class BaseAPI(Generic[T]):
         response = self.client.post(url, json_data=request_data, params=params)
         return self._process_response(response, is_collection=False)
 
-    def update(
-        self, resource_id: str, data: Union[T, Dict[str, Any]], **kwargs
-    ) -> T:
+    def update(self, resource_id: str, data: Union[T, Dict[str, Any]], **kwargs) -> T:
         """Update an existing resource.
 
         Args:
@@ -427,30 +423,34 @@ class BaseAPI(Generic[T]):
             page=page, per_page=per_page, filter_params=search_filters, **kwargs
         )
 
-    def get_by_id(self, resource_id: str, params: Optional[Dict[str, str]] = None) -> Optional[T]:
+    def get_by_id(
+        self, resource_id: str, params: Optional[Dict[str, str]] = None
+    ) -> Optional[T]:
         """Get a single resource by ID."""
         endpoint = self._build_url(resource_id)
         self.logger.info("Getting resource by ID", resource_id=resource_id)
-        
+
         try:
             response = self.client.get(endpoint, params=params or {})
-            
+
             if response and "data" in response:
                 return self.model_class.from_api_dict(response["data"])
             return None
-            
+
         except Exception as e:
-            self.logger.error("Failed to get resource", resource_id=resource_id, error=str(e))
+            self.logger.error(
+                "Failed to get resource", resource_id=resource_id, error=str(e)
+            )
             raise
 
     def get_all(self, params: Optional[Dict[str, str]] = None, **kwargs) -> List[T]:
         """Get all resources with pagination."""
         endpoint = self._build_url()
         self.logger.info("Getting all resources", params=params)
-        
+
         try:
             response = self.client.get(endpoint, params=params or {})
-            
+
             if response and "data" in response:
                 all_data = response["data"]
                 if isinstance(all_data, list):
@@ -458,39 +458,48 @@ class BaseAPI(Generic[T]):
                 else:
                     return [self.model_class.from_api_dict(all_data)]
             return []
-            
+
         except Exception as e:
             self.logger.error("Failed to get all resources", error=str(e))
             raise
 
-    def create(self, data: Dict[str, Any], params: Optional[Dict[str, str]] = None) -> Optional[T]:
+    def create(
+        self, data: Dict[str, Any], params: Optional[Dict[str, str]] = None
+    ) -> Optional[T]:
         """Create a new resource."""
         endpoint = self._build_url()
         self.logger.info("Creating resource", data=data)
-        
+
         try:
             response = self.client.post(endpoint, data=data, params=params or {})
-            
+
             if response and "data" in response:
                 return self.model_class.from_api_dict(response["data"])
             return None
-            
+
         except Exception as e:
             self.logger.error("Failed to create resource", error=str(e))
             raise
 
-    def update(self, resource_id: str, data: Dict[str, Any], params: Optional[Dict[str, str]] = None) -> Optional[T]:
+    def update(
+        self,
+        resource_id: str,
+        data: Dict[str, Any],
+        params: Optional[Dict[str, str]] = None,
+    ) -> Optional[T]:
         """Update an existing resource."""
         endpoint = self._build_url(resource_id)
         self.logger.info("Updating resource", resource_id=resource_id, data=data)
-        
+
         try:
             response = self.client.patch(endpoint, data=data, params=params or {})
-            
+
             if response and "data" in response:
                 return self.model_class.from_api_dict(response["data"])
             return None
-            
+
         except Exception as e:
-            self.logger.error("Failed to update resource", resource_id=resource_id, error=str(e))
+            self.logger.error(
+                "Failed to update resource", resource_id=resource_id, error=str(e)
+            )
             raise

--- a/itglue/api/configurations.py
+++ b/itglue/api/configurations.py
@@ -35,73 +35,77 @@ class ConfigurationsAPI(BaseAPI[Configuration]):
         self, name: str, exact_match: bool = False, **kwargs
     ) -> Optional[Configuration]:
         """Get configuration by name.
-        
+
         Args:
             name: Configuration name to search for
             exact_match: If True, performs exact match; otherwise fuzzy search
             **kwargs: Additional query parameters
-            
+
         Returns:
             Configuration if found, None otherwise
         """
         logger.info(f"Getting configuration by name: {name}")
-        
+
         if exact_match:
             # Use exact filter for exact match
             kwargs["filter_params"] = {"name": name}
             kwargs["per_page"] = 1
-            
+
             result = self.list(**kwargs)
             return result.data[0] if result.data else None
         else:
             # Use search for fuzzy matching
             return self.search(name, **kwargs)
 
-    def list_by_organization(self, organization_id: str, **kwargs) -> ITGlueResourceCollection[Configuration]:
+    def list_by_organization(
+        self, organization_id: str, **kwargs
+    ) -> ITGlueResourceCollection[Configuration]:
         """List configurations for a specific organization.
-        
+
         Args:
             organization_id: ID of the organization
             **kwargs: Additional query parameters
-            
+
         Returns:
             ConfigurationCollection containing matching configurations
         """
         logger.info(f"Listing configurations for organization: {organization_id}")
-        
+
         filter_params = kwargs.get("filter_params", {})
         filter_params["organization-id"] = organization_id
         kwargs["filter_params"] = filter_params
-        
+
         return self.list(**kwargs)
 
-    def list_by_type(self, configuration_type_id: str, **kwargs) -> ITGlueResourceCollection[Configuration]:
+    def list_by_type(
+        self, configuration_type_id: str, **kwargs
+    ) -> ITGlueResourceCollection[Configuration]:
         """List configurations by type.
-        
+
         Args:
             configuration_type_id: ID of the configuration type
             **kwargs: Additional query parameters
-            
+
         Returns:
             ConfigurationCollection containing matching configurations
         """
         logger.info(f"Listing configurations by type: {configuration_type_id}")
-        
+
         filter_params = kwargs.get("filter_params", {})
         filter_params["configuration-type-id"] = configuration_type_id
         kwargs["filter_params"] = filter_params
-        
+
         return self.list(**kwargs)
 
     def list_by_status(
         self, status: Union[ConfigurationStatus, str], **kwargs
     ) -> ITGlueResourceCollection[Configuration]:
         """List configurations by status.
-        
+
         Args:
             status: Configuration status (enum or string)
             **kwargs: Additional query parameters
-            
+
         Returns:
             ConfigurationCollection containing matching configurations
         """
@@ -109,87 +113,97 @@ class ConfigurationsAPI(BaseAPI[Configuration]):
             status_name = status.value
         else:
             status_name = status
-            
+
         logger.info(f"Listing configurations by status: {status_name}")
-        
+
         filter_params = kwargs.get("filter_params", {})
         filter_params["configuration-status-name"] = status_name
         kwargs["filter_params"] = filter_params
-        
+
         return self.list(**kwargs)
 
-    def get_active_configurations(self, **kwargs) -> ITGlueResourceCollection[Configuration]:
+    def get_active_configurations(
+        self, **kwargs
+    ) -> ITGlueResourceCollection[Configuration]:
         """Get all active configurations.
-        
+
         Args:
             **kwargs: Additional query parameters
-            
+
         Returns:
             ConfigurationCollection containing active configurations
         """
         return self.list_by_status(ConfigurationStatus.ACTIVE, **kwargs)
 
-    def search_by_hostname(self, hostname: str, **kwargs) -> ITGlueResourceCollection[Configuration]:
+    def search_by_hostname(
+        self, hostname: str, **kwargs
+    ) -> ITGlueResourceCollection[Configuration]:
         """Search configurations by hostname.
-        
+
         Args:
             hostname: Hostname to search for
             **kwargs: Additional query parameters
-            
+
         Returns:
             ConfigurationCollection containing matching configurations
         """
         logger.info(f"Searching configurations by hostname: {hostname}")
-        
+
         filter_params = kwargs.get("filter_params", {})
         filter_params["hostname"] = hostname
         kwargs["filter_params"] = filter_params
-        
+
         return self.list(**kwargs)
 
-    def search_by_ip_address(self, ip_address: str, **kwargs) -> ITGlueResourceCollection[Configuration]:
+    def search_by_ip_address(
+        self, ip_address: str, **kwargs
+    ) -> ITGlueResourceCollection[Configuration]:
         """Search configurations by IP address.
-        
+
         Args:
             ip_address: IP address to search for
             **kwargs: Additional query parameters
-            
+
         Returns:
             ConfigurationCollection containing matching configurations
         """
         logger.info(f"Searching configurations by IP: {ip_address}")
-        
+
         filter_params = kwargs.get("filter_params", {})
         filter_params["primary-ip"] = ip_address
         kwargs["filter_params"] = filter_params
-        
+
         return self.list(**kwargs)
 
     def update_status(
         self, configuration_id: str, status: Union[ConfigurationStatus, str], **kwargs
     ) -> Configuration:
         """Update configuration status.
-        
+
         Args:
             configuration_id: ID of the configuration to update
             status: New status (enum or string)
             **kwargs: Additional query parameters
-            
+
         Returns:
             Updated Configuration
-            
+
         Raises:
             ITGlueValidationError: If status is invalid
         """
         if isinstance(status, ConfigurationStatus):
             status_name = status.value
-        elif isinstance(status, str) and status in [s.value for s in ConfigurationStatus]:
+        elif isinstance(status, str) and status in [
+            s.value for s in ConfigurationStatus
+        ]:
             status_name = status
         else:
             raise ITGlueValidationError(f"Invalid configuration status: {status}")
-            
-        logger.info(f"Updating configuration {configuration_id} status to: {status_name}")
-        
+
+        logger.info(
+            f"Updating configuration {configuration_id} status to: {status_name}"
+        )
+
         data = {"configuration-status-name": status_name}
         return self.update(configuration_id, data, **kwargs)
 
@@ -205,7 +219,7 @@ class ConfigurationsAPI(BaseAPI[Configuration]):
         **kwargs,
     ) -> Configuration:
         """Create a new configuration.
-        
+
         Args:
             organization_id: ID of the organization
             name: Configuration name
@@ -215,18 +229,20 @@ class ConfigurationsAPI(BaseAPI[Configuration]):
             operating_system_notes: Optional OS notes
             notes: Optional general notes
             **kwargs: Additional configuration attributes
-            
+
         Returns:
             Created Configuration
         """
-        logger.info(f"Creating configuration: {name} for organization {organization_id}")
-        
+        logger.info(
+            f"Creating configuration: {name} for organization {organization_id}"
+        )
+
         data = {
             "organization-id": organization_id,
             "name": name,
             "configuration-type-id": configuration_type_id,
         }
-        
+
         # Add optional fields
         if hostname:
             data["hostname"] = hostname
@@ -236,33 +252,37 @@ class ConfigurationsAPI(BaseAPI[Configuration]):
             data["operating-system-notes"] = operating_system_notes
         if notes:
             data["notes"] = notes
-            
+
         # Add any additional kwargs
         data.update(kwargs)
-        
+
         return self.create(data)
 
     def bulk_update_status(
         self, configuration_ids: List[str], status: Union[ConfigurationStatus, str]
     ) -> List[Configuration]:
         """Bulk update status for multiple configurations.
-        
+
         Args:
             configuration_ids: List of configuration IDs to update
             status: New status for all configurations
-            
+
         Returns:
             List of updated Configuration objects
         """
         if isinstance(status, ConfigurationStatus):
             status_name = status.value
-        elif isinstance(status, str) and status in [s.value for s in ConfigurationStatus]:
+        elif isinstance(status, str) and status in [
+            s.value for s in ConfigurationStatus
+        ]:
             status_name = status
         else:
             raise ITGlueValidationError(f"Invalid configuration status: {status}")
-            
-        logger.info(f"Bulk updating {len(configuration_ids)} configurations to status: {status_name}")
-        
+
+        logger.info(
+            f"Bulk updating {len(configuration_ids)} configurations to status: {status_name}"
+        )
+
         updated_configs = []
         for config_id in configuration_ids:
             try:
@@ -270,55 +290,59 @@ class ConfigurationsAPI(BaseAPI[Configuration]):
                 updated_configs.append(updated_config)
             except Exception as e:
                 logger.error(f"Failed to update configuration {config_id}: {e}")
-                
+
         return updated_configs
 
     def get_configuration_statistics(self) -> Dict[str, Any]:
         """Get statistics about configurations.
-        
+
         Returns:
             Dictionary containing configuration statistics
         """
         logger.info("Getting configuration statistics")
-        
+
         # Get all configurations for analysis
         all_configs = self.list_all()
-        
+
         stats = {
             "total_count": len(all_configs.data),
             "by_status": {},
             "by_type": {},
             "by_organization": {},
         }
-        
+
         for config in all_configs.data:
             # Count by status
             status = config.configuration_status_name or "Unknown"
             stats["by_status"][status] = stats["by_status"].get(status, 0) + 1
-            
+
             # Count by type
             config_type = config.configuration_type_name or "Unknown"
             stats["by_type"][config_type] = stats["by_type"].get(config_type, 0) + 1
-            
+
             # Count by organization
             org_id = config.organization_id or "Unknown"
-            stats["by_organization"][org_id] = stats["by_organization"].get(org_id, 0) + 1
-            
+            stats["by_organization"][org_id] = (
+                stats["by_organization"].get(org_id, 0) + 1
+            )
+
         return stats
 
-    def get_organization_configuration_report(self, organization_id: str) -> Dict[str, Any]:
+    def get_organization_configuration_report(
+        self, organization_id: str
+    ) -> Dict[str, Any]:
         """Get detailed configuration report for an organization.
-        
+
         Args:
             organization_id: ID of the organization
-            
+
         Returns:
             Dictionary containing organization configuration report
         """
         logger.info(f"Getting configuration report for organization: {organization_id}")
-        
+
         configs = self.list_by_organization(organization_id)
-        
+
         report = {
             "organization_id": organization_id,
             "total_configurations": len(configs.data),
@@ -326,7 +350,7 @@ class ConfigurationsAPI(BaseAPI[Configuration]):
             "retired_configurations": len([c for c in configs.data if c.is_retired()]),
             "configurations_by_type": {},
         }
-        
+
         for config in configs.data:
             config_type = config.configuration_type_name or "Unknown"
             if config_type not in report["configurations_by_type"]:
@@ -335,11 +359,11 @@ class ConfigurationsAPI(BaseAPI[Configuration]):
                     "active": 0,
                     "retired": 0,
                 }
-            
+
             report["configurations_by_type"][config_type]["total"] += 1
             if config.is_active():
                 report["configurations_by_type"][config_type]["active"] += 1
             elif config.is_retired():
                 report["configurations_by_type"][config_type]["retired"] += 1
-                
+
         return report

--- a/itglue/api/flexible_assets.py
+++ b/itglue/api/flexible_assets.py
@@ -312,9 +312,7 @@ class FlexibleAssetsAPI(BaseAPI[FlexibleAsset]):
 
         data = {"type": "flexible_assets", "attributes": {"traits": updated_traits}}
 
-        response = self.client.patch(
-            self._build_url(flexible_asset_id), {"data": data}
-        )
+        response = self.client.patch(self._build_url(flexible_asset_id), {"data": data})
         return FlexibleAsset.from_api_dict(response["data"])
 
     def add_tags(
@@ -341,9 +339,7 @@ class FlexibleAssetsAPI(BaseAPI[FlexibleAsset]):
 
         data = {"type": "flexible_assets", "attributes": {"tag_list": updated_tags}}
 
-        response = self.client.patch(
-            self._build_url(flexible_asset_id), {"data": data}
-        )
+        response = self.client.patch(self._build_url(flexible_asset_id), {"data": data})
         return FlexibleAsset.from_api_dict(response["data"])
 
     def remove_tags(
@@ -367,9 +363,7 @@ class FlexibleAssetsAPI(BaseAPI[FlexibleAsset]):
 
         data = {"type": "flexible_assets", "attributes": {"tag_list": updated_tags}}
 
-        response = self.client.patch(
-            self._build_url(flexible_asset_id), {"data": data}
-        )
+        response = self.client.patch(self._build_url(flexible_asset_id), {"data": data})
         return FlexibleAsset.from_api_dict(response["data"])
 
     def update_status(
@@ -393,9 +387,7 @@ class FlexibleAssetsAPI(BaseAPI[FlexibleAsset]):
 
         data = {"type": "flexible_assets", "attributes": {"status": status_value}}
 
-        response = self.client.patch(
-            self._build_url(flexible_asset_id), {"data": data}
-        )
+        response = self.client.patch(self._build_url(flexible_asset_id), {"data": data})
         return FlexibleAsset.from_api_dict(response["data"])
 
     def get_asset_statistics(

--- a/itglue/api/organizations.py
+++ b/itglue/api/organizations.py
@@ -52,9 +52,7 @@ class OrganizationsAPI(BaseAPI[Organization]):
             # Use partial matching
             filter_params = {"name": f"*{name}*"}
 
-        results = self.list(
-            filter_params=filter_params, include=include, per_page=1
-        )
+        results = self.list(filter_params=filter_params, include=include, per_page=1)
 
         return results.data[0] if results.data else None
 

--- a/itglue/api/passwords.py
+++ b/itglue/api/passwords.py
@@ -172,7 +172,7 @@ class PasswordsAPI(BaseAPI[Password]):
         self,
         category: Union[PasswordCategory, str],
         organization_id: Optional[str] = None,
-        **params
+        **params,
     ) -> List[Password]:
         """
         Filter passwords by security category.
@@ -199,7 +199,7 @@ class PasswordsAPI(BaseAPI[Password]):
         self,
         visibility: Union[PasswordVisibility, str],
         organization_id: Optional[str] = None,
-        **params
+        **params,
     ) -> List[Password]:
         """
         Filter passwords by visibility level.
@@ -226,7 +226,7 @@ class PasswordsAPI(BaseAPI[Password]):
         self,
         password_type: Union[PasswordType, str],
         organization_id: Optional[str] = None,
-        **params
+        **params,
     ) -> List[Password]:
         """
         Filter passwords by type.
@@ -277,9 +277,7 @@ class PasswordsAPI(BaseAPI[Password]):
         Returns:
             List of high security passwords
         """
-        high_passwords = self.filter_by_category(
-            PasswordCategory.HIGH, organization_id
-        )
+        high_passwords = self.filter_by_category(PasswordCategory.HIGH, organization_id)
         critical_passwords = self.filter_by_category(
             PasswordCategory.CRITICAL, organization_id
         )
@@ -343,9 +341,7 @@ class PasswordsAPI(BaseAPI[Password]):
         Returns:
             List of private passwords
         """
-        return self.filter_by_visibility(
-            PasswordVisibility.PRIVATE, organization_id
-        )
+        return self.filter_by_visibility(PasswordVisibility.PRIVATE, organization_id)
 
     def get_embedded_passwords(
         self, organization_id: Optional[str] = None
@@ -500,7 +496,7 @@ class PasswordsAPI(BaseAPI[Password]):
         password_category: Union[PasswordCategory, str] = PasswordCategory.LOW,
         visibility: Union[PasswordVisibility, str] = PasswordVisibility.PRIVATE,
         favorite: bool = False,
-        **additional_fields
+        **additional_fields,
     ) -> Password:
         """
         Create a new password.
@@ -558,9 +554,7 @@ class PasswordsAPI(BaseAPI[Password]):
 
         return self.create(data)
 
-    def update_password_value(
-        self, password_id: str, new_password: str
-    ) -> Password:
+    def update_password_value(self, password_id: str, new_password: str) -> Password:
         """
         Update password value.
 
@@ -724,9 +718,7 @@ class PasswordsAPI(BaseAPI[Password]):
 
         return stats
 
-    def get_organization_password_report(
-        self, organization_id: str
-    ) -> Dict[str, Any]:
+    def get_organization_password_report(self, organization_id: str) -> Dict[str, Any]:
         """
         Get comprehensive password report for an organization.
 
@@ -738,9 +730,7 @@ class PasswordsAPI(BaseAPI[Password]):
         """
         stats = self.get_password_statistics(organization_id)
         stale_passwords = self.get_stale_passwords(90, organization_id)
-        recent_passwords = self.get_recently_updated_passwords(
-            30, organization_id
-        )
+        recent_passwords = self.get_recently_updated_passwords(30, organization_id)
 
         return {
             **stats,

--- a/itglue/cache.py
+++ b/itglue/cache.py
@@ -93,8 +93,10 @@ class MemoryCache(CacheBackend):
         if len(self.cache) >= self.max_size and key not in self.cache:
             # Remove 20% of oldest entries
             cleanup_count = max(1, int(self.max_size * 0.2))
-            oldest_keys = sorted(self.access_times.items(), key=lambda x: x[1])[:cleanup_count]
-            
+            oldest_keys = sorted(self.access_times.items(), key=lambda x: x[1])[
+                :cleanup_count
+            ]
+
             for old_key, _ in oldest_keys:
                 self.cache.pop(old_key, None)
                 self.access_times.pop(old_key, None)
@@ -190,7 +192,9 @@ class RedisCache(CacheBackend):
 
         except Exception as e:
             self.logger.error("Redis delete error", key=key, error=str(e))
-            raise ITGlueCacheError(f"Failed to delete from Redis cache: {e}")
+            # Error message, not a SQL query (bandit B608 false positive).
+            msg = f"Failed to delete from Redis cache: {e}"  # nosec B608
+            raise ITGlueCacheError(msg)
 
     def clear(self) -> None:
         """Clear all cache entries with our prefix."""
@@ -271,7 +275,8 @@ class CacheManager:
             key_data["params"] = dict(sorted(params.items()))
 
         key_string = json.dumps(key_data, sort_keys=True)
-        cache_key = hashlib.md5(key_string.encode()).hexdigest()
+        # MD5 is used purely to derive a compact cache key, not for security.
+        cache_key = hashlib.md5(key_string.encode(), usedforsecurity=False).hexdigest()
 
         return cache_key
 

--- a/itglue/http_client.py
+++ b/itglue/http_client.py
@@ -38,7 +38,9 @@ from .exceptions import (
 class SimpleRateLimiter:
     """Simple rate limiter for API requests."""
 
-    def __init__(self, requests_per_minute: int = 120, requests_per_5_minutes: int = 500):
+    def __init__(
+        self, requests_per_minute: int = 120, requests_per_5_minutes: int = 500
+    ):
         self.requests_per_minute = requests_per_minute
         self.requests_per_5_minutes = requests_per_5_minutes
         self.minute_requests: List[float] = []

--- a/itglue/models/base.py
+++ b/itglue/models/base.py
@@ -236,19 +236,20 @@ class ITGlueResource(BaseModel, Generic[T]):
         """Parse datetime string into datetime object."""
         if not value:
             return None
-        
+
         if isinstance(value, datetime):
             return value
-            
+
         if isinstance(value, str):
             try:
                 # Handle ISO format with microseconds and timezone
-                if value.endswith('Z'):
-                    value = value[:-1] + '+00:00'
+                if value.endswith("Z"):
+                    value = value[:-1] + "+00:00"
                 return datetime.fromisoformat(value)
             except ValueError:
                 # Try common datetime formats
                 from datetime import datetime as dt
+
                 formats = [
                     "%Y-%m-%dT%H:%M:%S.%f%z",
                     "%Y-%m-%dT%H:%M:%S%z",
@@ -260,7 +261,7 @@ class ITGlueResource(BaseModel, Generic[T]):
                         return dt.strptime(value, fmt)
                     except ValueError:
                         continue
-                
+
         return None
 
     def get_relationship(self, name: str) -> Optional[ITGlueRelationship]:

--- a/itglue/models/configuration.py
+++ b/itglue/models/configuration.py
@@ -294,7 +294,7 @@ class ConfigurationCollection(ITGlueResourceCollection[Configuration]):
         """Create ConfigurationCollection from API response."""
         if resource_class is None:
             resource_class = Configuration
-        
+
         base_collection = super().from_api_dict(data, resource_class)
         return cls(
             data=base_collection.data,

--- a/itglue/models/flexible_asset.py
+++ b/itglue/models/flexible_asset.py
@@ -329,7 +329,7 @@ class FlexibleAssetCollection(ITGlueResourceCollection[FlexibleAsset]):
         """Create FlexibleAssetCollection from API response."""
         if resource_class is None:
             resource_class = FlexibleAsset
-        
+
         base_collection = super().from_api_dict(data, resource_class)
         return cls(
             data=base_collection.data,
@@ -381,12 +381,14 @@ class FlexibleAssetTypeCollection(ITGlueResourceCollection[FlexibleAssetType]):
 
     @classmethod
     def from_api_dict(
-        cls, data: Dict[str, Any], resource_class: Optional[Type[FlexibleAssetType]] = None
+        cls,
+        data: Dict[str, Any],
+        resource_class: Optional[Type[FlexibleAssetType]] = None,
     ) -> "FlexibleAssetTypeCollection":
         """Create FlexibleAssetTypeCollection from API response."""
         if resource_class is None:
             resource_class = FlexibleAssetType
-        
+
         base_collection = super().from_api_dict(data, resource_class)
         return cls(
             data=base_collection.data,
@@ -412,12 +414,14 @@ class FlexibleAssetFieldCollection(ITGlueResourceCollection[FlexibleAssetField])
 
     @classmethod
     def from_api_dict(
-        cls, data: Dict[str, Any], resource_class: Optional[Type[FlexibleAssetField]] = None
+        cls,
+        data: Dict[str, Any],
+        resource_class: Optional[Type[FlexibleAssetField]] = None,
     ) -> "FlexibleAssetFieldCollection":
         """Create FlexibleAssetFieldCollection from API response."""
         if resource_class is None:
             resource_class = FlexibleAssetField
-        
+
         base_collection = super().from_api_dict(data, resource_class)
         return cls(
             data=base_collection.data,

--- a/itglue/models/organization.py
+++ b/itglue/models/organization.py
@@ -188,7 +188,7 @@ class OrganizationCollection(ITGlueResourceCollection[Organization]):
         """Create OrganizationCollection from API response."""
         if resource_class is None:
             resource_class = Organization
-        
+
         base_collection = super().from_api_dict(data, resource_class)
         return cls(
             data=base_collection.data,

--- a/itglue/models/password.py
+++ b/itglue/models/password.py
@@ -55,15 +55,16 @@ class Password(ITGlueResource):
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Override setattr to handle property setters for hyphenated attributes."""
-        # Define mapping of Python property names to API attribute names
+        # Define mapping of Python property names to API attribute names.
+        # These are field-name strings, not credentials (bandit B105 false positive).
         property_mappings = {
             "name": "name",
             "username": "username",
-            "password": "password",
+            "password": "password",  # nosec B105
             "url": "url",
             "notes": "notes",
-            "password_type": "password-type",
-            "password_category": "password-category-name",
+            "password_type": "password-type",  # nosec B105
+            "password_category": "password-category-name",  # nosec B105
             "visibility": "visibility",
             "auto_fill_selectors": "autofill-selectors",
             "favorite": "favorite",
@@ -345,7 +346,7 @@ class PasswordCollection(ITGlueResourceCollection[Password]):
         """Create PasswordCollection from API response."""
         if resource_class is None:
             resource_class = Password
-        
+
         base_collection = super().from_api_dict(data, resource_class)
         return cls(
             data=base_collection.data,

--- a/itglue/models/user.py
+++ b/itglue/models/user.py
@@ -286,7 +286,7 @@ class UserCollection(ITGlueResourceCollection[User]):
         """Create UserCollection from API response."""
         if resource_class is None:
             resource_class = User
-        
+
         base_collection = super().from_api_dict(data, resource_class)
         return cls(
             data=base_collection.data,

--- a/itglue/pagination.py
+++ b/itglue/pagination.py
@@ -118,27 +118,33 @@ class PaginationHandler:
                 params[key] = str(value)
         return params
 
-    def get_page(self, endpoint: str, page: int, page_size: Optional[int] = None, **kwargs) -> PaginatedResponse:
+    def get_page(
+        self, endpoint: str, page: int, page_size: Optional[int] = None, **kwargs
+    ) -> PaginatedResponse:
         """Get specific page."""
         params = self.build_params(**kwargs)
         params["page[number]"] = str(page)
-        
+
         if page_size:
             params["page[size]"] = str(page_size)
-        
+
         response = self.http_client.get(endpoint, params=params)
         self.last_response = response
         return self.parse_response(response)
 
-    def get_next_page(self, endpoint: str, current_response: PaginatedResponse, **kwargs) -> Optional[PaginatedResponse]:
+    def get_next_page(
+        self, endpoint: str, current_response: PaginatedResponse, **kwargs
+    ) -> Optional[PaginatedResponse]:
         """Get next page of results."""
         if not current_response.pagination.has_next:
             return None
-        
+
         next_page = current_response.pagination.next_page
         return self.get_page(endpoint, next_page, **kwargs)
 
-    def get_prev_page(self, endpoint: str, current_response: PaginatedResponse, **kwargs) -> Optional[PaginatedResponse]:
+    def get_prev_page(
+        self, endpoint: str, current_response: PaginatedResponse, **kwargs
+    ) -> Optional[PaginatedResponse]:
         """Get the previous page based on current response."""
         if not current_response.pagination.has_prev:
             return None
@@ -146,36 +152,42 @@ class PaginationHandler:
         prev_page = current_response.pagination.prev_page
         return self.get_page(endpoint, prev_page, **kwargs)
 
-    def get_all_pages(self, endpoint: str, page_size: Optional[int] = None, max_pages: Optional[int] = None, **kwargs) -> PaginatedResponse:
+    def get_all_pages(
+        self,
+        endpoint: str,
+        page_size: Optional[int] = None,
+        max_pages: Optional[int] = None,
+        **kwargs,
+    ) -> PaginatedResponse:
         """Get all pages of results."""
         all_data = []
         page_num = 1
         pages_fetched = 0
-        
+
         while True:
             if max_pages and pages_fetched >= max_pages:
                 break
-                
+
             response = self.get_page(endpoint, page_num, page_size, **kwargs)
             if not response or not response.data:
                 break
-                
+
             all_data.extend(response.data)
             pages_fetched += 1
-            
+
             # Check if there are more pages
             if not response.pagination.has_next:
                 break
-                
+
             page_num = response.pagination.next_page
-            
+
         # Create combined response
         combined_meta = {
             "total-count": len(all_data),
             "current-page": 1,
             "total-pages": pages_fetched,
         }
-        
+
         return PaginatedResponse(all_data, combined_meta, {})
 
     def iterate_pages(
@@ -241,7 +253,7 @@ class PaginationHandler:
         """Get current page information from last response."""
         if not self.last_response:
             return {}
-            
+
         meta = self.last_response.get("meta", {})
         return {
             "current_page": meta.get("current-page", 1),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,19 +35,24 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
     "pytest-asyncio>=0.21.0",
-    "black>=23.0.0",
+    # Pinned to the 26.x stable style so CI's `black --check` cannot drift
+    # when a new black release ships next year's formatting rules.
+    "black>=26.0,<27.0",
     "flake8>=6.0.0",
     "mypy>=1.0.0",
     "types-requests>=2.32.0",
     "pre-commit>=3.0.0",
     "bandit>=1.7.0",
-    "safety>=2.3.0",
+    "pip-audit>=2.7.0",
 ]
 testing = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
     "pytest-asyncio>=0.21.0",
+]
+performance = [
+    "psutil>=5.9.0",
 ]
 redis = [
     "redis>=4.5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,8 +43,8 @@ responses>=0.23.0
 factory-boy>=3.3.3
 faker>=40.15.0
 
-# Performance
-uvloop>=0.22.1
+# Performance (uvloop has no Windows support, so skip it there)
+uvloop>=0.22.1; sys_platform != 'win32'
 
 # Type hints
 types-requests>=2.31.0

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -329,7 +329,9 @@ class TestAPIOperations:
 
         with patch.object(test_api, "_process_response") as mock_process:
             # Create mock resource with the expected attributes
-            mock_resource = MockTestResource(id="123", attributes={"name": "Updated Org"})
+            mock_resource = MockTestResource(
+                id="123", attributes={"name": "Updated Org"}
+            )
             mock_process.return_value = mock_resource
 
             data = {"name": "Updated Org"}
@@ -352,9 +354,7 @@ class TestAPIOperations:
 
     def test_delete_resource_not_found(self, test_api, mock_http_client):
         """Test deleting non-existent resource raises not found error."""
-        mock_http_client.delete = Mock(
-            side_effect=ITGlueAPIError("Not found", 404)
-        )
+        mock_http_client.delete = Mock(side_effect=ITGlueAPIError("Not found", 404))
 
         with pytest.raises(ITGlueNotFoundError, match="Organizations 123 not found"):
             test_api.delete("123")

--- a/tests/test_api_flexible_assets.py
+++ b/tests/test_api_flexible_assets.py
@@ -26,7 +26,6 @@ from itglue.models.flexible_asset import (
 from itglue.exceptions import ITGlueValidationError
 
 
-
 class TestFlexibleAssetsAPI:
     """Test FlexibleAssetsAPI class."""
 
@@ -361,9 +360,7 @@ class TestFlexibleAssetsAPI:
         )
         assert isinstance(result, FlexibleAsset)
 
-    def test_add_tags(
-        self, flexible_assets_api, mock_http_client, sample_asset_data
-    ):
+    def test_add_tags(self, flexible_assets_api, mock_http_client, sample_asset_data):
         """Test adding tags to flexible asset."""
         # Mock get call for current asset
         current_asset_data = {
@@ -429,9 +426,7 @@ class TestFlexibleAssetsAPI:
         mock_http_client.patch.return_value = sample_asset_data
 
         # Test with enum
-        result = flexible_assets_api.update_status(
-            "123", FlexibleAssetStatus.ARCHIVED
-        )
+        result = flexible_assets_api.update_status("123", FlexibleAssetStatus.ARCHIVED)
 
         expected_data = {
             "data": {"type": "flexible_assets", "attributes": {"status": "Archived"}}
@@ -465,7 +460,6 @@ class TestFlexibleAssetsAPI:
 
         # Verify correct API calls were made
         assert mock_http_client.get.call_count == 3
-
 
 
 class TestFlexibleAssetTypesAPI:
@@ -588,7 +582,6 @@ class TestFlexibleAssetTypesAPI:
         assert isinstance(result, FlexibleAssetFieldCollection)
 
 
-
 class TestFlexibleAssetFieldsAPI:
     """Test FlexibleAssetFieldsAPI class."""
 
@@ -680,9 +673,7 @@ class TestFlexibleAssetFieldsAPI:
         )
 
         # Test with asset type filter
-        flexible_asset_fields_api.get_by_kind(
-            "Number", flexible_asset_type_id="123"
-        )
+        flexible_asset_fields_api.get_by_kind("Number", flexible_asset_type_id="123")
 
         expected_params = {
             "filter[kind]": "Number",

--- a/tests/test_api_organizations.py
+++ b/tests/test_api_organizations.py
@@ -100,9 +100,7 @@ class TestOrganizationsAPISpecializedMethods:
             mock_org = Organization.from_api_dict(sample_organization_data)
             mock_process.return_value = mock_org
 
-            result = organizations_api.update_status(
-                "123", OrganizationStatus.INACTIVE
-            )
+            result = organizations_api.update_status("123", OrganizationStatus.INACTIVE)
 
             assert result == mock_org
             mock_http_client.patch.assert_called_once()

--- a/tests/test_api_passwords.py
+++ b/tests/test_api_passwords.py
@@ -112,10 +112,7 @@ class TestPasswordsAPIInitialization:
 class TestPasswordsAPISearch:
     """Test search and filtering operations."""
 
-    
-    def test_search_passwords(
-        self, passwords_api, sample_password_collection_data
-    ):
+    def test_search_passwords(self, passwords_api, sample_password_collection_data):
         """Test searching passwords by query."""
         passwords_api.list = Mock(
             return_value=[
@@ -131,15 +128,12 @@ class TestPasswordsAPISearch:
         assert len(results) == 1
         assert results[0].name == "Gmail"
 
-    
     def test_get_by_name_exact_match(
         self, passwords_api, sample_password_collection_data
     ):
         """Test getting password by exact name match."""
         password_data = sample_password_collection_data["data"][0]
-        passwords_api.list = Mock(
-            return_value=[Password.from_api_dict(password_data)]
-        )
+        passwords_api.list = Mock(return_value=[Password.from_api_dict(password_data)])
 
         result = passwords_api.get_by_name("Gmail", organization_id="456")
 
@@ -149,22 +143,18 @@ class TestPasswordsAPISearch:
         assert result is not None
         assert result.name == "Gmail"
 
-    
     def test_get_by_name_case_insensitive(
         self, passwords_api, sample_password_collection_data
     ):
         """Test getting password by name with case insensitive matching."""
         password_data = sample_password_collection_data["data"][0]
-        passwords_api.list = Mock(
-            return_value=[Password.from_api_dict(password_data)]
-        )
+        passwords_api.list = Mock(return_value=[Password.from_api_dict(password_data)])
 
         result = passwords_api.get_by_name("gmail")  # lowercase
 
         assert result is not None
         assert result.name == "Gmail"
 
-    
     def test_get_by_name_not_found(self, passwords_api):
         """Test getting password by name when not found."""
         passwords_api.list = Mock(return_value=[])
@@ -173,15 +163,10 @@ class TestPasswordsAPISearch:
 
         assert result is None
 
-    
-    def test_search_by_username(
-        self, passwords_api, sample_password_collection_data
-    ):
+    def test_search_by_username(self, passwords_api, sample_password_collection_data):
         """Test searching passwords by username."""
         password_data = sample_password_collection_data["data"][0]
-        passwords_api.list = Mock(
-            return_value=[Password.from_api_dict(password_data)]
-        )
+        passwords_api.list = Mock(return_value=[Password.from_api_dict(password_data)])
 
         results = passwords_api.search_by_username(
             "user1@example.com", organization_id="456"
@@ -196,14 +181,11 @@ class TestPasswordsAPISearch:
         assert len(results) == 1
         assert results[0].username == "user1@example.com"
 
-    
     def test_search_by_url(self, passwords_api, sample_password_collection_data):
         """Test searching passwords by URL."""
         password_data = sample_password_collection_data["data"][0]
         password_data["attributes"]["url"] = "https://gmail.com"
-        passwords_api.list = Mock(
-            return_value=[Password.from_api_dict(password_data)]
-        )
+        passwords_api.list = Mock(return_value=[Password.from_api_dict(password_data)])
 
         results = passwords_api.search_by_url("gmail.com", organization_id="456")
 
@@ -216,7 +198,6 @@ class TestPasswordsAPISearch:
 class TestPasswordsAPIOrganizationFiltering:
     """Test organization-based filtering."""
 
-    
     def test_get_organization_passwords(
         self, passwords_api, sample_password_collection_data
     ):
@@ -237,7 +218,6 @@ class TestPasswordsAPIOrganizationFiltering:
         )
         assert len(results) == 2
 
-    
     def test_get_organization_passwords_include_archived(
         self, passwords_api, sample_password_collection_data
     ):
@@ -249,9 +229,7 @@ class TestPasswordsAPIOrganizationFiltering:
             ]
         )
 
-        results = passwords_api.get_organization_passwords(
-            "456", include_archived=True
-        )
+        results = passwords_api.get_organization_passwords("456", include_archived=True)
 
         passwords_api.list.assert_called_once_with(
             params={"filter[organization-id]": "456"}
@@ -262,15 +240,12 @@ class TestPasswordsAPIOrganizationFiltering:
 class TestPasswordsAPISecurityFiltering:
     """Test security and visibility filtering."""
 
-    
     def test_filter_by_category_enum(
         self, passwords_api, sample_password_collection_data
     ):
         """Test filtering by password category using enum."""
         password_data = sample_password_collection_data["data"][1]  # critical password
-        passwords_api.list = Mock(
-            return_value=[Password.from_api_dict(password_data)]
-        )
+        passwords_api.list = Mock(return_value=[Password.from_api_dict(password_data)])
 
         results = passwords_api.filter_by_category(
             PasswordCategory.CRITICAL, organization_id="456"
@@ -285,15 +260,12 @@ class TestPasswordsAPISecurityFiltering:
         assert len(results) == 1
         assert results[0].password_category == PasswordCategory.CRITICAL
 
-    
     def test_filter_by_category_string(
         self, passwords_api, sample_password_collection_data
     ):
         """Test filtering by password category using string."""
         password_data = sample_password_collection_data["data"][0]  # high password
-        passwords_api.list = Mock(
-            return_value=[Password.from_api_dict(password_data)]
-        )
+        passwords_api.list = Mock(return_value=[Password.from_api_dict(password_data)])
 
         results = passwords_api.filter_by_category("high")
 
@@ -302,15 +274,12 @@ class TestPasswordsAPISecurityFiltering:
         )
         assert len(results) == 1
 
-    
     def test_filter_by_visibility_enum(
         self, passwords_api, sample_password_collection_data
     ):
         """Test filtering by visibility using enum."""
         password_data = sample_password_collection_data["data"][0]  # private password
-        passwords_api.list = Mock(
-            return_value=[Password.from_api_dict(password_data)]
-        )
+        passwords_api.list = Mock(return_value=[Password.from_api_dict(password_data)])
 
         results = passwords_api.filter_by_visibility(
             PasswordVisibility.PRIVATE, organization_id="456"
@@ -322,15 +291,10 @@ class TestPasswordsAPISecurityFiltering:
         assert len(results) == 1
         assert results[0].visibility == PasswordVisibility.PRIVATE
 
-    
-    def test_filter_by_type_enum(
-        self, passwords_api, sample_password_collection_data
-    ):
+    def test_filter_by_type_enum(self, passwords_api, sample_password_collection_data):
         """Test filtering by password type using enum."""
         password_data = sample_password_collection_data["data"][0]  # embedded password
-        passwords_api.list = Mock(
-            return_value=[Password.from_api_dict(password_data)]
-        )
+        passwords_api.list = Mock(return_value=[Password.from_api_dict(password_data)])
 
         results = passwords_api.filter_by_type(PasswordType.EMBEDDED)
 
@@ -344,7 +308,6 @@ class TestPasswordsAPISecurityFiltering:
 class TestPasswordsAPISecurityMethods:
     """Test security-focused methods."""
 
-    
     def test_get_critical_passwords(
         self, passwords_api, sample_password_collection_data
     ):
@@ -362,7 +325,6 @@ class TestPasswordsAPISecurityMethods:
         assert len(results) == 1
         assert results[0].password_category == PasswordCategory.CRITICAL
 
-    
     def test_get_high_security_passwords(
         self, passwords_api, sample_password_collection_data
     ):
@@ -386,7 +348,6 @@ class TestPasswordsAPISecurityMethods:
         assert passwords_api.filter_by_category.call_count == 2
         assert len(results) == 2  # Should include both high and critical
 
-    
     def test_get_high_security_passwords_deduplication(
         self, passwords_api, sample_password_collection_data
     ):
@@ -407,10 +368,7 @@ class TestPasswordsAPISecurityMethods:
 
         assert len(results) == 1  # Should be deduplicated
 
-    
-    def test_get_shared_passwords(
-        self, passwords_api, sample_password_collection_data
-    ):
+    def test_get_shared_passwords(self, passwords_api, sample_password_collection_data):
         """Test getting shared passwords."""
         shared_password = Password.from_api_dict(
             sample_password_collection_data["data"][1]
@@ -430,7 +388,6 @@ class TestPasswordsAPISecurityMethods:
         assert len(results) == 1
         assert results[0].visibility == PasswordVisibility.ORGANIZATION
 
-    
     def test_get_private_passwords(
         self, passwords_api, sample_password_collection_data
     ):
@@ -448,7 +405,6 @@ class TestPasswordsAPISecurityMethods:
         assert len(results) == 1
         assert results[0].visibility == PasswordVisibility.PRIVATE
 
-    
     def test_get_embedded_passwords(
         self, passwords_api, sample_password_collection_data
     ):
@@ -466,10 +422,7 @@ class TestPasswordsAPISecurityMethods:
         assert len(results) == 1
         assert results[0].password_type == PasswordType.EMBEDDED
 
-    
-    def test_get_linked_passwords(
-        self, passwords_api, sample_password_collection_data
-    ):
+    def test_get_linked_passwords(self, passwords_api, sample_password_collection_data):
         """Test getting linked passwords."""
         linked_password = Password.from_api_dict(
             sample_password_collection_data["data"][1]
@@ -486,7 +439,6 @@ class TestPasswordsAPISecurityMethods:
 class TestPasswordsAPISpecialStates:
     """Test special state filtering methods."""
 
-    
     def test_get_favorite_passwords(
         self, passwords_api, sample_password_collection_data
     ):
@@ -504,7 +456,6 @@ class TestPasswordsAPISpecialStates:
         assert len(results) == 1
         assert results[0].favorite is True
 
-    
     def test_get_archived_passwords(
         self, passwords_api, sample_password_collection_data
     ):
@@ -522,10 +473,7 @@ class TestPasswordsAPISpecialStates:
         assert len(results) == 1
         assert results[0].archived is True
 
-    
-    def test_get_active_passwords(
-        self, passwords_api, sample_password_collection_data
-    ):
+    def test_get_active_passwords(self, passwords_api, sample_password_collection_data):
         """Test getting active passwords."""
         active_password = Password.from_api_dict(
             sample_password_collection_data["data"][0]
@@ -544,7 +492,6 @@ class TestPasswordsAPISpecialStates:
 class TestPasswordsAPITimeFiltering:
     """Test time-based filtering methods."""
 
-    
     def test_get_recently_updated_passwords(
         self, passwords_api, sample_password_collection_data
     ):
@@ -566,10 +513,7 @@ class TestPasswordsAPITimeFiltering:
         # Verify that the date filter contains an ISO date string
         assert "T" in call_args["filter[updated-at][gt]"]  # ISO format check
 
-    
-    def test_get_stale_passwords(
-        self, passwords_api, sample_password_collection_data
-    ):
+    def test_get_stale_passwords(self, passwords_api, sample_password_collection_data):
         """Test getting stale passwords."""
         stale_password = Password.from_api_dict(
             sample_password_collection_data["data"][0]
@@ -590,7 +534,6 @@ class TestPasswordsAPITimeFiltering:
 class TestPasswordsAPIManagement:
     """Test password management operations."""
 
-    
     def test_create_password(self, passwords_api, sample_password_data):
         """Test creating a new password."""
         passwords_api.create = Mock(
@@ -630,7 +573,6 @@ class TestPasswordsAPIManagement:
 
         assert result.name == "Gmail Account"
 
-    
     def test_create_password_with_string_enums(
         self, passwords_api, sample_password_data
     ):
@@ -654,7 +596,6 @@ class TestPasswordsAPIManagement:
         assert call_args["attributes"]["password-category-name"] == "critical"
         assert call_args["attributes"]["visibility"] == "everyone"
 
-    
     def test_update_password_value(self, passwords_api, sample_password_data):
         """Test updating password value."""
         passwords_api.update = Mock(
@@ -670,10 +611,7 @@ class TestPasswordsAPIManagement:
         assert update_data["type"] == ResourceType.PASSWORDS.value
         assert update_data["attributes"]["password"] == "newpassword"
 
-    
-    def test_update_password_visibility(
-        self, passwords_api, sample_password_data
-    ):
+    def test_update_password_visibility(self, passwords_api, sample_password_data):
         """Test updating password visibility."""
         passwords_api.update = Mock(
             return_value=Password.from_api_dict(sample_password_data)
@@ -689,7 +627,6 @@ class TestPasswordsAPIManagement:
         update_data = call_args[0][1]
         assert update_data["attributes"]["visibility"] == "everyone"
 
-    
     def test_update_password_category(self, passwords_api, sample_password_data):
         """Test updating password security category."""
         passwords_api.update = Mock(
@@ -704,7 +641,6 @@ class TestPasswordsAPIManagement:
         update_data = call_args[0][1]
         assert update_data["attributes"]["password-category-name"] == "critical"
 
-    
     def test_toggle_favorite(self, passwords_api, sample_password_data):
         """Test toggling password favorite status."""
         # Mock current password state
@@ -728,7 +664,6 @@ class TestPasswordsAPIManagement:
         update_data = call_args[0][1]
         assert update_data["attributes"]["favorite"] is False  # Toggled from True
 
-    
     def test_archive_password(self, passwords_api, sample_password_data):
         """Test archiving a password."""
         passwords_api.update = Mock(
@@ -741,7 +676,6 @@ class TestPasswordsAPIManagement:
         update_data = call_args[0][1]
         assert update_data["attributes"]["archived"] is True
 
-    
     def test_unarchive_password(self, passwords_api, sample_password_data):
         """Test unarchiving a password."""
         passwords_api.update = Mock(
@@ -758,7 +692,6 @@ class TestPasswordsAPIManagement:
 class TestPasswordsAPIAnalytics:
     """Test analytics and reporting methods."""
 
-    
     def test_get_password_statistics_empty(self, passwords_api):
         """Test getting statistics for empty password collection."""
         passwords_api.get_active_passwords = Mock(return_value=[])
@@ -770,7 +703,6 @@ class TestPasswordsAPIAnalytics:
         assert stats["archived_passwords"] == 0
         assert stats["critical_passwords"] == 0
 
-    
     def test_get_password_statistics(
         self, passwords_api, sample_password_collection_data
     ):
@@ -782,9 +714,7 @@ class TestPasswordsAPIAnalytics:
         archived_passwords = []
 
         passwords_api.get_active_passwords = Mock(return_value=active_passwords)
-        passwords_api.get_archived_passwords = Mock(
-            return_value=archived_passwords
-        )
+        passwords_api.get_archived_passwords = Mock(return_value=archived_passwords)
 
         stats = passwords_api.get_password_statistics(organization_id="456")
 
@@ -804,7 +734,6 @@ class TestPasswordsAPIAnalytics:
         assert "visibility_distribution" in stats
         assert "type_distribution" in stats
 
-    
     def test_get_organization_password_report(
         self, passwords_api, sample_password_collection_data
     ):

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -81,10 +81,7 @@ class TestUsersAPI:
             ]
         }
 
-    
-    def test_get_by_email_found(
-        self, users_api, mock_client, sample_users_list_data
-    ):
+    def test_get_by_email_found(self, users_api, mock_client, sample_users_list_data):
         """Test getting user by email when user exists."""
         mock_client.get.return_value = sample_users_list_data
 
@@ -101,7 +98,6 @@ class TestUsersAPI:
                 params={"filter[email]": "john@example.com"}, page_size=1
             )
 
-    
     def test_get_by_email_not_found(self, users_api, mock_client):
         """Test getting user by email when user doesn't exist."""
         with patch.object(users_api, "list", new_callable=Mock) as mock_list:
@@ -114,14 +110,12 @@ class TestUsersAPI:
                 params={"filter[email]": "nonexistent@example.com"}, page_size=1
             )
 
-    
     def test_get_by_email_error(self, users_api, mock_client):
         """Test error handling in get_by_email."""
         with patch.object(users_api, "list", side_effect=Exception("Network error")):
             with pytest.raises(ITGlueAPIError, match="Failed to get user by email"):
                 users_api.get_by_email("test@example.com")
 
-    
     def test_search_by_name(self, users_api, mock_client, sample_users_list_data):
         """Test searching users by name."""
         with patch.object(users_api, "list", new_callable=Mock) as mock_list:
@@ -139,7 +133,6 @@ class TestUsersAPI:
             }
             mock_list.assert_called_once_with(params=expected_params)
 
-    
     def test_search_by_name_with_collection(
         self, users_api, mock_client, sample_users_list_data
     ):
@@ -153,7 +146,6 @@ class TestUsersAPI:
             assert isinstance(result, list)
             assert len(result) == 2
 
-    
     def test_filter_by_role_string(
         self, users_api, mock_client, sample_users_list_data
     ):
@@ -170,10 +162,7 @@ class TestUsersAPI:
             assert result[0].role_name == "Admin"
             mock_list.assert_called_once_with(params={"filter[role-name]": "Admin"})
 
-    
-    def test_filter_by_role_enum(
-        self, users_api, mock_client, sample_users_list_data
-    ):
+    def test_filter_by_role_enum(self, users_api, mock_client, sample_users_list_data):
         """Test filtering users by role using enum."""
         with patch.object(users_api, "list", new_callable=Mock) as mock_list:
             mock_users = [
@@ -187,10 +176,7 @@ class TestUsersAPI:
             assert result[0].role_name == "Editor"
             mock_list.assert_called_once_with(params={"filter[role-name]": "Editor"})
 
-    
-    def test_get_active_users(
-        self, users_api, mock_client, sample_users_list_data
-    ):
+    def test_get_active_users(self, users_api, mock_client, sample_users_list_data):
         """Test getting active users."""
         with patch.object(users_api, "list", new_callable=Mock) as mock_list:
             mock_users = [
@@ -203,10 +189,7 @@ class TestUsersAPI:
             expected_params = {"filter[invitation-accepted-at]": "!null"}
             mock_list.assert_called_once_with(params=expected_params)
 
-    
-    def test_get_invited_users(
-        self, users_api, mock_client, sample_users_list_data
-    ):
+    def test_get_invited_users(self, users_api, mock_client, sample_users_list_data):
         """Test getting invited users."""
         with patch.object(users_api, "list", new_callable=Mock) as mock_list:
             mock_users = [
@@ -222,10 +205,7 @@ class TestUsersAPI:
             }
             mock_list.assert_called_once_with(params=expected_params)
 
-    
-    def test_get_my_glue_users(
-        self, users_api, mock_client, sample_users_list_data
-    ):
+    def test_get_my_glue_users(self, users_api, mock_client, sample_users_list_data):
         """Test getting MyGlue users."""
         with patch.object(users_api, "list", new_callable=Mock) as mock_list:
             mock_users = [
@@ -238,7 +218,6 @@ class TestUsersAPI:
             expected_params = {"filter[my-glue]": "true"}
             mock_list.assert_called_once_with(params=expected_params)
 
-    
     def test_get_recently_active_users(
         self, users_api, mock_client, sample_users_list_data
     ):
@@ -257,7 +236,6 @@ class TestUsersAPI:
             assert "filter[last-sign-in-at]" in call_args
             assert ">=" in call_args["filter[last-sign-in-at]"]
 
-    
     def test_get_top_reputation_users(
         self, users_api, mock_client, sample_users_list_data
     ):
@@ -273,7 +251,6 @@ class TestUsersAPI:
             expected_params = {"sort": "-reputation", "page[size]": "5"}
             mock_list.assert_called_once_with(params=expected_params)
 
-    
     def test_create_user(self, users_api, mock_client, sample_user_data):
         """Test creating a new user."""
         with patch.object(users_api, "create", new_callable=Mock) as mock_create:
@@ -291,7 +268,6 @@ class TestUsersAPI:
             assert isinstance(result, User)
             mock_create.assert_called_once_with(user_data)
 
-    
     def test_update_user_role(self, users_api, mock_client, sample_user_data):
         """Test updating user role."""
         with patch.object(users_api, "update", new_callable=Mock) as mock_update:
@@ -302,7 +278,6 @@ class TestUsersAPI:
             assert isinstance(result, User)
             mock_update.assert_called_once_with("123", {"role-name": "Creator"})
 
-    
     def test_update_user_profile(self, users_api, mock_client, sample_user_data):
         """Test updating user profile."""
         with patch.object(users_api, "update", new_callable=Mock) as mock_update:
@@ -319,7 +294,6 @@ class TestUsersAPI:
             assert isinstance(result, User)
             mock_update.assert_called_once_with("123", profile_data)
 
-    
     def test_resend_invitation(self, users_api, mock_client):
         """Test resending invitation to user."""
         mock_client.post.return_value = {"success": True}
@@ -329,7 +303,6 @@ class TestUsersAPI:
         assert result is True
         mock_client.post.assert_called_once_with("users/123/resend_invitation")
 
-    
     def test_resend_invitation_error(self, users_api, mock_client):
         """Test error handling in resend_invitation."""
         mock_client.post.side_effect = Exception("Network error")
@@ -337,10 +310,7 @@ class TestUsersAPI:
         with pytest.raises(ITGlueAPIError, match="Failed to resend invitation"):
             users_api.resend_invitation("123")
 
-    
-    def test_get_user_statistics(
-        self, users_api, mock_client, sample_users_list_data
-    ):
+    def test_get_user_statistics(self, users_api, mock_client, sample_users_list_data):
         """Test getting user statistics."""
         with patch.object(users_api, "list", new_callable=Mock) as mock_list:
             mock_collection = UserCollection.from_api_dict(sample_users_list_data)
@@ -361,10 +331,7 @@ class TestUsersAPI:
             assert isinstance(result["my_glue_statistics"], dict)
             assert isinstance(result["top_reputation_users"], list)
 
-    
-    def test_search_users_with_email(
-        self, users_api, mock_client, sample_user_data
-    ):
+    def test_search_users_with_email(self, users_api, mock_client, sample_user_data):
         """Test searching users with email query."""
         with patch.object(
             users_api, "get_by_email", new_callable=Mock
@@ -383,7 +350,6 @@ class TestUsersAPI:
                 mock_get_by_email.assert_called_once_with("john@example.com")
                 mock_search_by_name.assert_called_once_with("john@example.com")
 
-    
     def test_search_users_without_email(
         self, users_api, mock_client, sample_users_list_data
     ):
@@ -405,7 +371,6 @@ class TestUsersAPI:
                 mock_get_by_email.assert_not_called()  # No @ in query
                 mock_search_by_name.assert_called_once_with("John")
 
-    
     def test_search_users_duplicate_removal(
         self, users_api, mock_client, sample_user_data
     ):
@@ -425,7 +390,6 @@ class TestUsersAPI:
                 assert len(result) == 1  # Duplicate removed
                 assert result[0].id == "123"
 
-    
     def test_get_admin_users(self, users_api, mock_client):
         """Test getting admin users."""
         with patch.object(
@@ -437,7 +401,6 @@ class TestUsersAPI:
 
             mock_filter.assert_called_once_with(UserRole.ADMIN)
 
-    
     def test_get_creator_users(self, users_api, mock_client):
         """Test getting creator users."""
         with patch.object(
@@ -449,7 +412,6 @@ class TestUsersAPI:
 
             mock_filter.assert_called_once_with(UserRole.CREATOR)
 
-    
     def test_get_editor_users(self, users_api, mock_client):
         """Test getting editor users."""
         with patch.object(
@@ -461,7 +423,6 @@ class TestUsersAPI:
 
             mock_filter.assert_called_once_with(UserRole.EDITOR)
 
-    
     def test_get_lite_users(self, users_api, mock_client):
         """Test getting lite users."""
         with patch.object(
@@ -473,7 +434,6 @@ class TestUsersAPI:
 
             mock_filter.assert_called_once_with(UserRole.LITE)
 
-    
     def test_get_viewer_users(self, users_api, mock_client):
         """Test getting viewer users."""
         with patch.object(
@@ -485,7 +445,6 @@ class TestUsersAPI:
 
             mock_filter.assert_called_once_with(UserRole.VIEWER)
 
-    
     def test_api_initialization(self, mock_client):
         """Test API initialization with correct parameters."""
         api = UsersAPI(mock_client)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -298,7 +298,7 @@ class TestCacheManager:
     def test_cache_manager_redis_backend(self, config_redis):
         """Test cache manager with Redis backend."""
         redis = pytest.importorskip("redis")
-        
+
         with patch.object(redis, "from_url") as mock_redis_from_url:
             mock_redis_client = Mock()
             mock_redis_from_url.return_value = mock_redis_client
@@ -312,7 +312,7 @@ class TestCacheManager:
     def test_cache_manager_redis_import_error(self, config_redis):
         """Test fallback to memory cache when Redis import fails."""
         redis = pytest.importorskip("redis")
-        
+
         with patch.object(redis, "from_url") as mock_redis_from_url:
             mock_redis_from_url.side_effect = ImportError("Redis not available")
 
@@ -325,7 +325,7 @@ class TestCacheManager:
     def test_cache_manager_redis_connection_error(self, config_redis):
         """Test fallback to memory cache when Redis connection fails."""
         redis = pytest.importorskip("redis")
-        
+
         with patch.object(redis, "from_url") as mock_redis_from_url:
             mock_redis_from_url.side_effect = Exception("Connection failed")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,9 +30,11 @@ class TestITGlueClient:
     @pytest.fixture
     def mock_components(self):
         """Create mock components."""
-        with patch("itglue.client.ITGlueHTTPClient") as mock_http, patch(
-            "itglue.client.PaginationHandler"
-        ) as mock_pagination, patch("itglue.client.CacheManager") as mock_cache:
+        with (
+            patch("itglue.client.ITGlueHTTPClient") as mock_http,
+            patch("itglue.client.PaginationHandler") as mock_pagination,
+            patch("itglue.client.CacheManager") as mock_cache,
+        ):
 
             # Configure mocks
             mock_http_instance = Mock()

--- a/tests/test_models_configuration.py
+++ b/tests/test_models_configuration.py
@@ -40,7 +40,7 @@ class TestConfiguration:
             id="123",
             name="Test Server",
             hostname="test-server.example.com",
-            **{"primary-ip": "192.168.1.100", "configuration-status-name": "Active"}
+            **{"primary-ip": "192.168.1.100", "configuration-status-name": "Active"},
         )
 
         assert config.id == "123"
@@ -131,7 +131,7 @@ class TestConfiguration:
             id="123",
             name="Test Server",
             hostname="test-server.example.com",
-            **{"configuration-status-name": "Active"}
+            **{"configuration-status-name": "Active"},
         )
 
         api_dict = config.to_api_dict()
@@ -155,17 +155,17 @@ class TestConfigurationCollection:
             Configuration(
                 id="2",
                 name="Planned Workstation",
-                **{"configuration-status-name": "Planned"}
+                **{"configuration-status-name": "Planned"},
             ),
             Configuration(
                 id="3",
                 name="Retired Router",
-                **{"configuration-status-name": "Retired"}
+                **{"configuration-status-name": "Retired"},
             ),
             Configuration(
                 id="4",
                 name="Another Active Server",
-                **{"configuration-status-name": "Active"}
+                **{"configuration-status-name": "Active"},
             ),
         ]
 

--- a/tests/test_models_organization.py
+++ b/tests/test_models_organization.py
@@ -51,7 +51,7 @@ class TestOrganization:
             id="123",
             name="Test Organization",
             description="A test organization",
-            **{"primary-domain": "example.com"}  # Use API field name
+            **{"primary-domain": "example.com"},  # Use API field name
         )
 
         assert org.id == "123"
@@ -129,7 +129,7 @@ class TestOrganization:
             **{
                 "created-at": "2023-08-01T12:00:00.000Z",
                 "updated-at": "2023-08-02T12:00:00.000Z",
-            }
+            },
         )
 
         assert org.created_at is not None
@@ -167,7 +167,10 @@ class TestOrganization:
         org = Organization(
             id="123",
             name="Test Organization",
-            **{"organization-type-name": "Client", "organization-status-name": "Active"}
+            **{
+                "organization-type-name": "Client",
+                "organization-status-name": "Active",
+            },
         )
 
         str_repr = str(org)
@@ -215,7 +218,7 @@ class TestOrganization:
             id="123",
             name="Test Organization",
             description="A test organization",
-            **{"organization-type-name": "Client"}
+            **{"organization-type-name": "Client"},
         )
 
         api_dict = org.to_api_dict()
@@ -239,7 +242,7 @@ class TestOrganizationCollection:
                 **{
                     "organization-type-name": "Client",
                     "organization-status-name": "Active",
-                }
+                },
             ),
             Organization(
                 id="2",
@@ -247,7 +250,7 @@ class TestOrganizationCollection:
                 **{
                     "organization-type-name": "Internal",
                     "organization-status-name": "Active",
-                }
+                },
             ),
             Organization(
                 id="3",
@@ -255,7 +258,7 @@ class TestOrganizationCollection:
                 **{
                     "organization-type-name": "Vendor",
                     "organization-status-name": "Inactive",
-                }
+                },
             ),
             Organization(
                 id="4",
@@ -263,7 +266,7 @@ class TestOrganizationCollection:
                 **{
                     "organization-type-name": "Client",
                     "organization-status-name": "Active",
-                }
+                },
             ),
         ]
 


### PR DESCRIPTION
## Summary
Fixes the failing **CI** and **Scheduled Tests** workflows. Four root causes, all addressed at source:

| Failure | Job | Root cause | Fix |
|---|---|---|---|
| `ModuleNotFoundError: No module named 'psutil'` | scheduled `comprehensive-test` | Workflow installs `.[...,performance]` but no `performance` extra existed | Add `performance` extra (`psutil`) to `pyproject.toml` |
| `safety check` exits 2/64 (`--policy-file` / `--output` errors) | CI `security` + scheduled `security-audit` | safety 3.x deprecated `check` and is auth-gated | Replace with PyPA **pip-audit** (no account, exits 0 clean) |
| `black --check` reformats 23 files | CI `test` | Unpinned black shipped a new stable style | Reformat with black 26.x **and** pin `black>=26.0,<27.0` |
| Bandit exits 1 (latent — never reached before because safety failed first) | both security jobs | 1 real MD5 finding + 3 false positives | `usedforsecurity=False` on the cache-key MD5; `# nosec` on B105 field-name mappings & B608 error-message f-string |

## Verification (local)
- ✅ 408 passed, 3 skipped (pytest)
- ✅ `black --check` clean · flake8 critical clean · mypy clean
- ✅ `bandit -r itglue` exit 0 · `pip-audit` → no known vulnerabilities

The large diff is mostly mechanical Black reformatting; the substantive changes are in `pyproject.toml`, `itglue/cache.py`, `itglue/models/password.py`, the two workflow files, and `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)